### PR TITLE
Add MkDocs documentation and Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.3] - 2024-06-14
+
+### Fixed
+
+- Fix bug in pep621 command where `-` in name but src folder is `_` 
+
+## [0.1.2] - 2024-06-14
+
+### Fixed
+
+- Fix bug in pep621 command.
+
+## [0.1.1] - 2024-01-20
+
+### Added
+
+- `--verbose` option
+
+### Fixed
+
+- Less noisy by default, most prints moved to logging invocations
+
+### Changed
+
+- Makes best efforts to find src folder even if different from package name.
+
+
+## [0.1.0] - 2024-01-20
+
+### Added
+
+- Application created.
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Contributions are welcome! To work on the project:
+
+1. Fork and clone the repository.
+2. Use the Justfile to install development dependencies with Poetry:
+
+   ```bash
+   just poetry-install
+   ```
+
+3. Run the test suite through the Justfile:
+
+   ```bash
+   just test
+   ```
+
+4. Submit a pull request describing your changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# metametameta
+
+metametameta generates an `__about__.py` file populated with common dunder metadata such as `__title__` and `__author__`. It extracts information from multiple sources and writes a standardized module you can ship with your project.
+
+See [Installation](installation.md) to get started and [Usage](usage.md) for examples. Contributions are welcome; see [Contributing](contributing.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,9 @@
+# Installation
+
+Install metametameta with [pipx](https://pypa.github.io/pipx/):
+
+```bash
+pipx install metametameta
+```
+
+You can also use `pip install metametameta` if you prefer.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,25 @@
+# Usage
+
+By default metametameta writes an `__about__.py` file in your package directory assuming the package name matches your main module:
+
+```bash
+metametameta poetry
+```
+
+You can specify the project name, source file, or output path:
+
+```bash
+metametameta poetry --name "something" --source some.toml --output OUTPUT "mod/meta/__meta__.py"
+```
+
+The command line interface provides subcommands for different metadata sources:
+
+```text
+usage: metametameta [-h] {setup_cfg,pep621,poetry,importlib} ...
+```
+
+Each subcommand accepts the same options:
+
+```text
+usage: metametameta poetry [-h] [--name NAME] [--source SOURCE] [--output OUTPUT]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: metametameta
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Usage: usage.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- add MkDocs site with pages for installation, usage, contributing, and changelog
- configure MkDocs navigation and Read the Docs build
- recommend using the Justfile and Poetry in the contributing guide

## Testing
- `pre-commit run --files docs/contributing.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3a72f1388327bfaf42bbb9bed508