### PR TITLE
chore: refine CI docs and publish triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - README.md
+      - docs/**
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.7
+    - uses: actions/setup-python@v5.1.1
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        pip install mkdocs mkdocs-material
+    - name: Deploy
+      run: mkdocs gh-deploy --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: Build and Test
+name: Publish
 
-on: [push]
+on:
+  workflow_dispatch:
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4.1.7
       with:
@@ -13,18 +13,18 @@ jobs:
     - uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.11'
-          # cache: 'pipenv' # caching pipenv dependencies
     - name: Install poetry and pipx
       run: |
         pip install poetry && pip install pipx
-
     - name: Install global dependencies
       run: |
         pipx install isort && pipx install black && pipx install bandit && \
         pipx install pylint && pipx install pre-commit && pipx install poetry
-
     - name: Install Dependencies
       run: poetry install --with dev
-
     - name: Run Makefile
       run: make check
+    - name: Build package
+      run: poetry run make publish
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.9.0


### PR DESCRIPTION
## Summary
- run build workflow only for tests
- add manual publish workflow
- publish docs only when README or docs change

## Testing
- `pre-commit run --files .github/workflows/build.yml .github/workflows/publish.yml .github/workflows/docs.yml`
- `bash run-pyenv-tox.sh`

------
https://chatgpt.com/codex/tasks/task_e_68975e09635c83278e45bd423334da09